### PR TITLE
PROT-2 Change the way the message is sent

### DIFF
--- a/src/main/java/br/com/krakatoa/protocolizer/form/MessageForm.java
+++ b/src/main/java/br/com/krakatoa/protocolizer/form/MessageForm.java
@@ -1,9 +1,7 @@
 package br.com.krakatoa.protocolizer.form;
 
 import br.com.krakatoa.protocolizer.model.ProtocolMessage;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -17,9 +15,9 @@ public class MessageForm {
     private String terminal;
     private String merchant;
     private String bitmap;
-    private Integer terminalStartPosition;
-    private Integer merchantStartPosition;
-    private Integer bitmapStartPosition;
+    private String originalTerminal;
+    private String originalMerchant;
+    private String originalBitmap;
 
     public ProtocolMessage toMessage() {
         return new ProtocolMessage(this);

--- a/src/main/java/br/com/krakatoa/protocolizer/model/ProtocolMessage.java
+++ b/src/main/java/br/com/krakatoa/protocolizer/model/ProtocolMessage.java
@@ -15,30 +15,31 @@ public class ProtocolMessage {
     private String bitmap;
     private String terminal;
     private String merchant;
-    private Integer bitmapStartPosition;
-    private Integer terminalStartPosition;
-    private Integer merchantStartPosition;
+    private String originalBitmap;
+    private String originalTerminal;
+    private String originalMerchant;
 
     public ProtocolMessage(MessageForm messageForm) {
         this.raw = messageForm.getRaw();
         this.bitmap = messageForm.getBitmap();
         this.terminal = messageForm.getTerminal();
         this.merchant = messageForm.getMerchant();
-        this.bitmapStartPosition = messageForm.getBitmapStartPosition();
-        this.terminalStartPosition = messageForm.getTerminalStartPosition();
-        this.merchantStartPosition = messageForm.getMerchantStartPosition();
+        this.originalBitmap = messageForm.getOriginalBitmap();
+        this.originalTerminal = messageForm.getOriginalTerminal();
+        this.originalMerchant = messageForm.getOriginalMerchant();
     }
 
     public String updateRaw() {
         StringBuilder sb = new StringBuilder(this.raw);
 
-        int bitmapFinalPosition = this.bitmapStartPosition + this.bitmap.length() - 1;
-        int terminalFinalPosition = this.terminalStartPosition + this.terminal.length() - 1;
-        int merchantFinalPosition = this.merchantStartPosition + this.merchant.length() - 1;
+        int bitmapIndex = sb.indexOf(this.originalBitmap);
+        int terminalIndex = sb.indexOf(this.originalTerminal);
+        int merchantIndex = sb.indexOf(this.originalMerchant);
 
-        sb.replace(this.bitmapStartPosition - 1, bitmapFinalPosition, this.bitmap);
-        sb.replace(this.terminalStartPosition - 1, terminalFinalPosition, this.terminal);
-        sb.replace(this.merchantStartPosition - 1, merchantFinalPosition, this.merchant);
+        sb.replace(bitmapIndex, bitmapIndex+this.bitmap.length(), this.bitmap);
+        sb.replace(terminalIndex, terminalIndex+this.terminal.length(), this.terminal);
+        sb.replace(merchantIndex, merchantIndex+this.merchant.length(), this.merchant);
+
         this.raw = sb.toString();
         return this.raw;
     }

--- a/src/test/java/br/com/krakatoa/protocolizer/ProtocolMessageTest.java
+++ b/src/test/java/br/com/krakatoa/protocolizer/ProtocolMessageTest.java
@@ -15,13 +15,9 @@ class ProtocolMessageTest {
 
         @Test
         void given() {
-            String expectedRaw = "ABCDEFABCDEFABCDEFABCDEFA";
+            String expectedRaw = "FFAAAAAAAAFFBBBBBBBBBBBBBFF";
             ProtocolMessage protocolMessage = ProtocolMessage.builder()
                     .raw(expectedRaw)
-                    .terminal("12345678")
-                    .terminalStartPosition(2)
-                    .merchant("123456789012")
-                    .merchantStartPosition(12)
                     .build();
 
             ProtocolMessageDto protocolMessageDto = protocolMessage.toDto();
@@ -36,13 +32,15 @@ class ProtocolMessageTest {
 
         @Test
         void given_MessageWithTerminalAndMerchant_When_UpdateRaw_Then_ReturnNewRaw() {
-            String expected = "A12345678DE123456789012FA";
+            String expected = "FFA94052125928425AFF12345678FF123456789012FF";
             ProtocolMessage protocolMessage = ProtocolMessage.builder()
-                    .raw("ABCDEFABCDEFABCDEFABCDEFA")
+                    .raw("FF0000000000000000FFAAAAAAAAFFBBBBBBBBBBBBFF")
+                    .bitmap("A94052125928425A")
+                    .originalBitmap("0000000000000000")
                     .terminal("12345678")
-                    .terminalStartPosition(2)
+                    .originalTerminal("AAAAAAAA")
                     .merchant("123456789012")
-                    .merchantStartPosition(12)
+                    .originalMerchant("BBBBBBBBBBBB")
                     .build();
 
             String rawMessage = protocolMessage.updateRaw();


### PR DESCRIPTION
The message is now sent in the following format:
{
	"raw": 
	"bitmap": 
	"terminal": 
	"merchant": 
	"originalBitmap": 
	"originalTerminal": 
        "originalMerchant": 
}